### PR TITLE
Prevent merge when branch is behind main

### DIFF
--- a/.github/workflows/prevent_merge_when_branch_behind.yml
+++ b/.github/workflows/prevent_merge_when_branch_behind.yml
@@ -19,6 +19,7 @@ jobs:
     
       - name: Fetch main branch
         run: |
+          git fetch --unshallow
           git fetch --all
           git status
 
@@ -28,6 +29,7 @@ jobs:
           echo "Current head: $(git rev-parse HEAD)"
           echo "Main: $(git rev-parse origin/main)"
           git branch -a
+          git log --oneline
           
 
 

--- a/.github/workflows/prevent_merge_when_branch_behind.yml
+++ b/.github/workflows/prevent_merge_when_branch_behind.yml
@@ -20,18 +20,7 @@ jobs:
       - name: Fetch main branch
         run: |
           git fetch --unshallow
-          git fetch --all
-          git status
-
-      - name: Print commit hashes
-        run: |
-          echo "Current branch: $(git rev-parse --abbrev-ref HEAD)"
-          echo "Current head: $(git rev-parse HEAD)"
-          echo "Main: $(git rev-parse origin/main)"
-          git branch -a
-          git log --oneline
-          
-
+          git fetch origin main
 
       - name: Compare branch with main
         run: |

--- a/.github/workflows/prevent_merge_when_branch_behind.yml
+++ b/.github/workflows/prevent_merge_when_branch_behind.yml
@@ -11,8 +11,12 @@ on:
 jobs:
   check-branch:
     runs-on: ubuntu-latest
-
     steps:
+      - name: Checkout pull request branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+    
       - name: Fetch main branch
         run: |
           git fetch origin main

--- a/.github/workflows/prevent_merge_when_branch_behind.yml
+++ b/.github/workflows/prevent_merge_when_branch_behind.yml
@@ -25,9 +25,9 @@ jobs:
       - name: Compare branch with main
         run: |
           if git merge-base --is-ancestor origin/main HEAD; then
-            echo "Branch is up-to-date with main."
+            echo "::notice ::Branch is up-to-date with main."
           else
-            echo "Branch is behind main. Aborting."
+            echo "::error ::Merge Blocked: Your branch is behind the latest commits on main. Please update your branch with the latest changes from main before attempting to merge."
             echo "Merge base: $(git merge-base HEAD origin/main)"
             exit 1
           fi

--- a/.github/workflows/prevent_merge_when_branch_behind.yml
+++ b/.github/workflows/prevent_merge_when_branch_behind.yml
@@ -22,7 +22,7 @@ jobs:
           git fetch origin main
       - name: Compare branch with main
         run: |
-          if ! git merge-base --is-ancestor HEAD origin/main; then
+          if ! git merge-base --is-ancestor origin/main HEAD; then
             echo "Branch is behind main. Aborting."
             exit 1
           fi

--- a/.github/workflows/prevent_merge_when_branch_behind.yml
+++ b/.github/workflows/prevent_merge_when_branch_behind.yml
@@ -19,7 +19,7 @@ jobs:
     
       - name: Fetch main branch
         run: |
-          git fetch origin main
+          git fetch --all
           git status
 
       - name: Print commit hashes
@@ -27,17 +27,23 @@ jobs:
           echo "Current branch: $(git rev-parse --abbrev-ref HEAD)"
           echo "Current head: $(git rev-parse HEAD)"
           echo "Main: $(git rev-parse origin/main)"
+          git branch -a
+          git log --oneline --graph --decorate
           BASE=$(git merge-base HEAD origin/main)
-          echo "Merge base: $BASE"
+          if [ $? -eq 0 ]; then
+            echo "Merge base: $BASE"
+          else
+            echo "Failed to find merge base."
+          fi
 
 
       - name: Compare branch with main
         run: |
-          if ! git merge-base --is-ancestor origin/main HEAD; then
+          if git merge-base --is-ancestor origin/main HEAD; then
+            echo "Branch is up-to-date with main."
+          else
             echo "Branch is behind main. Aborting."
             exit 1
-          else
-            echo "Branch is up-to-date with main."
           fi
 
  

--- a/.github/workflows/prevent_merge_when_branch_behind.yml
+++ b/.github/workflows/prevent_merge_when_branch_behind.yml
@@ -28,13 +28,7 @@ jobs:
           echo "Current head: $(git rev-parse HEAD)"
           echo "Main: $(git rev-parse origin/main)"
           git branch -a
-          git log --oneline --graph --decorate
-          BASE=$(git merge-base HEAD origin/main)
-          if [ $? -eq 0 ]; then
-            echo "Merge base: $BASE"
-          else
-            echo "Failed to find merge base."
-          fi
+          
 
 
       - name: Compare branch with main
@@ -43,6 +37,7 @@ jobs:
             echo "Branch is up-to-date with main."
           else
             echo "Branch is behind main. Aborting."
+            echo "Merge base: $(git merge-base HEAD origin/main)"
             exit 1
           fi
 

--- a/.github/workflows/prevent_merge_when_branch_behind.yml
+++ b/.github/workflows/prevent_merge_when_branch_behind.yml
@@ -1,0 +1,29 @@
+name: Require Branch to Be Up-to-Date with Main
+
+# Trigger this workflow on pull request events targeting a specific branch.
+on:
+  pull_request:
+    branches:
+      - main
+      - test-protect-main-merge # for testing
+  workflow_dispatch: # enables manual triggering
+
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch main branch
+        run: |
+          git fetch origin main
+      - name: Compare branch with main
+        run: |
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "Branch is behind main. Aborting."
+            exit 1
+          fi
+      - name: Approve merge if branch is up to date
+        run: |
+          echo "Branch is up-to-date with main."
+
+ 

--- a/.github/workflows/prevent_merge_when_branch_behind.yml
+++ b/.github/workflows/prevent_merge_when_branch_behind.yml
@@ -20,14 +20,24 @@ jobs:
       - name: Fetch main branch
         run: |
           git fetch origin main
+          git status
+
+      - name: Print commit hashes
+        run: |
+          echo "Current branch: $(git rev-parse --abbrev-ref HEAD)"
+          echo "Current head: $(git rev-parse HEAD)"
+          echo "Main: $(git rev-parse origin/main)"
+          BASE=$(git merge-base HEAD origin/main)
+          echo "Merge base: $BASE"
+
+
       - name: Compare branch with main
         run: |
           if ! git merge-base --is-ancestor origin/main HEAD; then
             echo "Branch is behind main. Aborting."
             exit 1
+          else
+            echo "Branch is up-to-date with main."
           fi
-      - name: Approve merge if branch is up to date
-        run: |
-          echo "Branch is up-to-date with main."
 
  


### PR DESCRIPTION
This is a GitHub workflow that fixes #74.
https://github.com/prio-data/views_pipeline/issues/74

This workflow runs every time a pull request is opened to the main branch. It fails if the branch is behind main and asks the user to update the branch manually.