### PR TITLE
Fix test eval metrics

### DIFF
--- a/common_utils/tests/test_utils_evaluation_metrics.py
+++ b/common_utils/tests/test_utils_evaluation_metrics.py
@@ -3,6 +3,7 @@ import pandas as pd
 import properscoring as ps
 from sklearn.metrics import mean_squared_error, mean_absolute_error
 # WARNING: mean_squared_error is deprecated!
+import wandb
 import sys
 from pathlib import Path
 PATH = Path(__file__)
@@ -43,11 +44,11 @@ def mock_config():
         Config: A mock configuration object with attributes 'steps' and 'depvar'.
     """
 
-    class Config:
-        steps = [1, 2]
-        depvar = "depvar"
+    config = wandb.Config()
+    config.steps = [1, 2]
+    config.depvar = "depvar"
 
-    return Config()
+    return config
 
 
 def test_evaluation_metrics_default_values():

--- a/common_utils/tests/test_utils_model_outputs.py
+++ b/common_utils/tests/test_utils_model_outputs.py
@@ -3,7 +3,7 @@ import pandas as pd
 from utils_model_outputs import ModelOutputs, generate_output_dict
 import sys
 from pathlib import Path
-
+import wandb
 PATH = Path(__file__)
 if 'views_pipeline' in PATH.parts:
     PATH_ROOT = Path(*PATH.parts[:PATH.parts.index('views_pipeline') + 1])
@@ -53,11 +53,11 @@ def mock_config():
         Config: A mock configuration object with predefined attributes.
     """
 
-    class Config:
-        steps = [1, 2]
-        depvar = "depvar"
+    config = wandb.Config()
+    config.steps = [1, 2]
+    config.depvar = "depvar"
 
-    return Config()
+    return config
 
 
 def test_model_outputs_default_values():


### PR DESCRIPTION
Fixed 2 failing tests:

`common_utils/tests/test_utils_evaluation_metrics.py::test_generate_metric_dict` FAILED 
`common_utils/tests/test_utils_model_outputs.py::test_generate_output_dict` FAILED 

Reason:
The config parameter in the docstring in generate_metric_dict() says that it requires a config dictionary which was being mocked. In reality it requires a wandb Config object.

Recommendation:
Update all docstrings and add type hints in `utils_evaluation_metrics.py` and `utils_model_outputs.py`.

Example:
```
Args:
        df (pd.DataFrame): A pandas DataFrame containing the forecasted values and ground truth.
        config (dict): A dictionary containing the forecasting configuration parameters.
```       
to this:
```
Args:
        df (pd.DataFrame): A pandas DataFrame containing the forecasted values and ground truth.
        config (dict): A wandb Config object containing the forecasting configuration parameters.
```